### PR TITLE
changes to arguments in runRSP

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RSP
 Title: Refined Shortest Paths
-Version: 0.0.1
+Version: 0.0.1.9001
 Authors@R: c(
     person("Yuri", "Niella", role = c("aut", "cre"), email = "yuri.niella@hdr.mq.edu.au"),
     person("Hugo", "Flávio", role = c("aut"), email = "hdmfla@aqua.dtu.dk", comment = c(ORCID = "0000-0002-5174-1197"))

--- a/R/dynBBMM.R
+++ b/R/dynBBMM.R
@@ -5,7 +5,7 @@
 #'
 #' @param input The output of runRSP.
 #' @param base.raster The water raster of the study area. For example the output of \code{\link[actel]{loadShape}}.
-#' @param tags Vector of transmitters to be analysand. By default all transmitters from runRSP will be analysed.
+#' @param tags Vector of transmitters to be analysed. By default all transmitters from runRSP will be analysed.
 #' @param start.time Sets the start point for analysis (format = "Y-m-d H:M:S").
 #' @param stop.time Sets the stop point for analysis (format = "Y-m-d H:M:S").
 #' @param UTM The UTM zone of the study area. Only relevant if a latlon-to-metric conversion is required.

--- a/R/run_helpers.R
+++ b/R/run_helpers.R
@@ -4,13 +4,13 @@
 #' then named based on the interval between consecutive detection dates.
 #'
 #' @param detections Detections data frame
-#' @param maximum.time Temporal lag in hours to be considered for the fine-scale tracking. Default is to consider 1-day intervals.
+#' @param max.time Temporal lag in hours to be considered for the fine-scale tracking. Default is to consider 1-day intervals.
 #' 
 #' @return A dataframe with identified and named individual tracks for RSP estimation.
 #' 
-nameTracks <- function(detections, maximum.time = 24) {
+nameTracks <- function(detections, max.time = 24) {
   # Assign tracks to detections
-  breaks <- which(detections$Time.lapse.min > maximum.time * 60)
+  breaks <- which(detections$Time.lapse.min > max.time * 60)
   starts <- c(1, breaks)
   stops  <- c(breaks, nrow(detections) + 1)
   n <- (stops - starts)
@@ -24,6 +24,7 @@ nameTracks <- function(detections, maximum.time = 24) {
   track.aux <- lapply(aux, function(x) {
     data.frame(Track = NA_character_,
       original.n = nrow(x),
+      new.n = nrow(x),
       First.time = x$Timestamp[1],
       Last.time = x$Timestamp[nrow(x)],
       Timespan = difftime(x$Timestamp[nrow(x)], x$Timestamp[1], units = "hours"),

--- a/man/calcRSP.Rd
+++ b/man/calcRSP.Rd
@@ -8,7 +8,8 @@ calcRSP(
   df.track,
   tz,
   distance,
-  time.lapse,
+  min.time,
+  time.step,
   transition,
   er.ad,
   path.list,
@@ -22,7 +23,9 @@ calcRSP(
 
 \item{distance}{Maximum distance between RSP locations.}
 
-\item{time.lapse}{Time lapse in minutes to be considered for consecutive detections at the same station.}
+\item{min.time}{Minimum time required between receiver detections (in minutes) for RSP to be calculated. Default to 10 minutes.}
+
+\item{time.step}{Time lapse in minutes to be considered for consecutive detections at the same station.}
 
 \item{transition}{TransitionLayer object as returned by LTDpath.}
 

--- a/man/dynBBMM.Rd
+++ b/man/dynBBMM.Rd
@@ -21,7 +21,7 @@ dynBBMM(
 
 \item{base.raster}{The water raster of the study area. For example the output of \code{\link[actel]{loadShape}}.}
 
-\item{tags}{Vector of transmitters to be analysand. By default all transmitters from runRSP will be analysed.}
+\item{tags}{Vector of transmitters to be analysed. By default all transmitters from runRSP will be analysed.}
 
 \item{start.time}{Sets the start point for analysis (format = "Y-m-d H:M:S").}
 

--- a/man/includeRSP.Rd
+++ b/man/includeRSP.Rd
@@ -9,9 +9,10 @@ includeRSP(
   transition,
   tz,
   distance,
-  time.lapse,
+  time.step,
   er.ad,
-  maximum.time,
+  min.time,
+  max.time,
   verbose,
   debug = FALSE
 )
@@ -23,13 +24,15 @@ includeRSP(
 
 \item{tz}{Timezone of the study area.}
 
-\item{distance}{Fixed distances in meters to add intermediate track locations. By default intermediate positions are added every 250 metres.}
+\item{distance}{Distance (in metres) by which RSP point should be spaced (between detections at different stations). Defaults to 250 metres.}
 
-\item{time.lapse}{Time lapse in minutes to be considered for consecutive detections at the same station.}
+\item{time.step}{Time lapse (in minutes) between RSP points added between detections at the same station. Defaults to 10 minutes. Must not be larger than \code{min.time}.}
 
-\item{er.ad}{By default, 5\% of the distance argument is used as the increment rate of the position errors for the estimated locations. Alternatively, can be defined by the user in meters.}
+\item{er.ad}{Increment rate of the position errors for the estimated locations (in metres). If left unset, defaults to 5\% of the \code{distance} argument.}
 
-\item{maximum.time}{Temporal lag in hours to be considered for the fine-scale tracking. Default is to consider 1-day intervals.}
+\item{min.time}{Minimum time required between receiver detections (in minutes) for RSP to be calculated. Default to 10 minutes.}
+
+\item{max.time}{Maximum time allowed between receiver detections (in hours) for RSP to be calculated. Defaults to 24 hours.}
 
 \item{verbose}{Logical: If TRUE, detailed messages and progression are displayed. Otherwise, a single progress bar is shown.}
 

--- a/man/nameTracks.Rd
+++ b/man/nameTracks.Rd
@@ -4,12 +4,12 @@
 \alias{nameTracks}
 \title{Identify potential fine-scale data for analysis}
 \usage{
-nameTracks(detections, maximum.time = 24)
+nameTracks(detections, max.time = 24)
 }
 \arguments{
 \item{detections}{Detections data frame}
 
-\item{maximum.time}{Temporal lag in hours to be considered for the fine-scale tracking. Default is to consider 1-day intervals.}
+\item{max.time}{Temporal lag in hours to be considered for the fine-scale tracking. Default is to consider 1-day intervals.}
 }
 \value{
 A dataframe with identified and named individual tracks for RSP estimation.

--- a/man/plotRaster.Rd
+++ b/man/plotRaster.Rd
@@ -12,11 +12,9 @@ plotRaster(input, base.raster, coord.x, coord.y, size, land.col = "#BABCBF80")
 
 \item{base.raster}{Raster object. Imported for example using \code{\link[actel]{loadShape}}.}
 
-\item{coord.x}{The names of the columns containing the x and y positions of the stations 
-in the spatial object.}
+\item{coord.x}{The names of the columns containing the x and y positions of the stations in the spatial object.}
 
-\item{coord.y}{The names of the columns containing the x and y positions of the stations 
-in the spatial object.}
+\item{coord.y}{The names of the columns containing the x and y positions of the stations in the spatial object.}
 
 \item{size}{The size of the station dots}
 

--- a/man/prepareDetections.Rd
+++ b/man/prepareDetections.Rd
@@ -11,11 +11,9 @@ prepareDetections(detections, spatial, coord.x, coord.y)
 
 \item{spatial}{A list of spatial objects in the study area}
 
-\item{coord.x}{The names of the columns containing the x and y positions of the stations 
-in the spatial object.}
+\item{coord.x}{The names of the columns containing the x and y positions of the stations in the spatial object.}
 
-\item{coord.y}{The names of the columns containing the x and y positions of the stations 
-in the spatial object.}
+\item{coord.y}{The names of the columns containing the x and y positions of the stations in the spatial object.}
 }
 \value{
 A standardised data frame to be used for RSP calculation.

--- a/man/runRSP.Rd
+++ b/man/runRSP.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/runRSP.R
 \name{runRSP}
 \alias{runRSP}
-\title{Refined Shortest Path (RSP) between detections}
+\title{Calculate refined shortest paths between detections}
 \usage{
 runRSP(
   input,
@@ -10,9 +10,11 @@ runRSP(
   coord.x,
   coord.y,
   distance = 250,
-  time.lapse = 10,
-  er.ad = NULL,
-  maximum.time = 24,
+  tags,
+  time.step = 10,
+  min.time = 10,
+  max.time = 24,
+  er.ad,
   verbose = FALSE,
   debug = FALSE
 )
@@ -20,31 +22,34 @@ runRSP(
 \arguments{
 \item{input}{The output of one of \code{\link[actel]{actel}}'s main functions (\code{\link[actel]{explore}}, \code{\link[actel]{migration}} or \code{\link[actel]{residency}})}
 
-\item{t.layer}{A transition layer calculated using the function \code{\link[actel]{transitionLayer}}}
+\item{t.layer}{A transition layer. Can be calculated using the function \code{\link[actel]{transitionLayer}}.}
 
-\item{coord.x, coord.y}{The names of the columns containing the x and y positions of the stations 
-in the spatial object.}
+\item{coord.x, coord.y}{The names of the columns containing the x and y positions of the stations in the spatial object.}
 
-\item{distance}{Fixed distances in meters to add intermediate track locations. By default intermediate positions are added every 250 metres.}
+\item{distance}{Distance (in metres) by which RSP point should be spaced (between detections at different stations). Defaults to 250 metres.}
 
-\item{time.lapse}{Time lapse in minutes to be considered for consecutive detections at the same station.}
+\item{tags}{Vector of transmitters for which to calculate RSP. By default all transmitters will be analysed.}
 
-\item{er.ad}{By default, 5\% of the distance argument is used as the increment rate of the position errors for the estimated locations. Alternatively, can be defined by the user in meters.}
+\item{time.step}{Time lapse (in minutes) between RSP points added between detections at the same station. Defaults to 10 minutes. Must not be larger than \code{min.time}.}
 
-\item{maximum.time}{Temporal lag in hours to be considered for the fine-scale tracking. Default is to consider 1-day intervals.}
+\item{min.time}{Minimum time required between receiver detections (in minutes) for RSP to be calculated. Default to 10 minutes.}
+
+\item{max.time}{Maximum time allowed between receiver detections (in hours) for RSP to be calculated. Defaults to 24 hours.}
+
+\item{er.ad}{Increment rate of the position errors for the estimated locations (in metres). If left unset, defaults to 5\% of the \code{distance} argument.}
 
 \item{verbose}{Logical: If TRUE, detailed messages and progression are displayed. Otherwise, a single progress bar is shown.}
 
 \item{debug}{Logical: If TRUE, the function progress is saved to an RData file.}
 }
 \value{
-Returns a list of RSP tracks (as data frame) for each transmitter detected.
+Returns a list of RSP tracks for each transmitter detected, as well as auxiliary information.
 }
 \description{
 Estimates the RSP for a series of animals tracked with acoustic transmitters. Intermediate
 locations between consecutive acoustic detections (either on the same or different receivers) are estimated 
-according to fixed distance (see distance for details) and temporal (see time.lapse for details) intervals. The error of estimated locations increase proportionally as 
-the animal moves away from the first detection, and decreases as it approaches the second detection (see er.ad for details). If 
+according to the defined \code{distance} and \code{time.step} arguments. The error of estimated locations increase proportionally as 
+the animal moves away from the first detection, and decreases as it approaches the second detection (argument \code{er.ad}). If 
 the animal is not detected for a long time (default is a daily absence), the detections are broken into a 
-new track (see maximum.time for details).
+new track (argument \code{max.time}).
 }


### PR DESCRIPTION
List of changes:

* Rename `time.lapse` to `time.step`, to avoid confusion with dynBBMM's `timelapse`
* Rename `maximum.time` to `max.time` for brevity and similarity with new added argument.
* New argument `min.time` sets the minimum time between detections for RSP points to be calculated.
* New argument `tags` works similar to its namesake in dynBBMM, allowing the user to calculate RSP only for a subset of tags.
* Updated documentation, including fixing a typo in dynBBMM
* Bumped the dev version to 9001

@YuriNiella please review and accept if all is looking good.