### PR TITLE
Changed getDistances function to look for NA

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -507,7 +507,9 @@ getDistances <- function(input, t.layer) {
             input$bio$Release.site[input$bio$Transmitter == tags[i]])
           release.point <- input$spatial$release.sites[index, c("Longitude", "Latitude")]
 
-        if (!is.na(release.point[1,1]) & nrow(release.point) > 0) {
+          if (!is.null(input$spatial$release.sites) && 
+                       nrow(release.point) > 0 && 
+                       !is.na(release.point[1,1])){
           A <- c(release.point[,1], release.point[,2])
           B <- with(df.rec, c(Longitude[1], Latitude[1]))
           # definitive AtoB's

--- a/R/get.R
+++ b/R/get.R
@@ -507,7 +507,7 @@ getDistances <- function(input, t.layer) {
             input$bio$Release.site[input$bio$Transmitter == tags[i]])
           release.point <- input$spatial$release.sites[index, c("Longitude", "Latitude")]
 
-        if (nrow(release.point) > 0) {
+        if (!is.na(release.point[1,1]) & nrow(release.point) > 0) {
           A <- c(release.point[,1], release.point[,2])
           B <- with(df.rec, c(Longitude[1], Latitude[1]))
           # definitive AtoB's

--- a/tests/testthat/test_dynBBMM_group.R
+++ b/tests/testthat/test_dynBBMM_group.R
@@ -214,11 +214,36 @@ test_that("plotDensities is working properly for group plot", {
 
 
 # plotDistances: but first getDistances has to work!
-test_that("getDistances is working properly", {
+test_that("getDistances runs", {
 	p <- tryCatch(getDistances(rsp.data, t.layer = tl), 
 		warning = function(w)
  	stop("A warning was issued in getDistances!", w))
 	expect_that(p, is_a("data.frame"))
+})
+
+test_that("getDistances can handle NA in LAT and LONG", {
+  nocoord_rsp <- rsp.data
+  nocoord_rsp$spatial$release.sites$Latitude <- NA
+  nocoord_rsp$spatial$release.sites$Longitude <- NA
+  nocoord_rsp$spatial$release.sites$x <- NA
+  nocoord_rsp$spatial$release.sites$y <- NA
+  p <- expect_warning(getDistances(nocoord_rsp, t.layer = tl),
+                      paste0(
+                        "Release location not found for A69-9001-1111", 
+                        ". The first track distance may be underestimated."),
+                      fixed = TRUE)
+  expect_that(p, is_a("data.frame"))
+})
+
+test_that("getDistances can handle empty release.point dataframe", {
+  null_rsp <- rsp.data
+  null_rsp$spatial$release.sites <- NULL
+  p <- expect_warning(getDistances(null_rsp, t.layer = tl),
+                      paste0(
+                        "Release location not found for A69-9001-1111", 
+                        ". The first track distance may be underestimated."),
+                      fixed = TRUE)
+  expect_that(p, is_a("data.frame"))
 })
 
 test_that("plotDistances is working properly", {


### PR DESCRIPTION
Checks if the first row and column of release.point is not NA and that the number of rows in release.point is greater than 0 before continuing with this part of the getDistances function.

This fixes an issue where if release.point had 1 row both with NA the function would error because no release lat and long were available. 